### PR TITLE
fix: add policies link to pricing page and cookie

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 					<p data-i18n="cookie.description2">
 						This website uses cookies to help personalize content and provide a safer experience.
 						<p>
-							<a href="privacy-policy.html#cookie-description" data-i18n="footer.privacy-policy">
+							<a href="policies/privacy-policy.html#cookie-description" data-i18n="footer.privacy-policy">
 								Privacy Policy
 							</a>
 						</p>
@@ -73,7 +73,7 @@
 					personalize content and provide a
 					safer experience.
 					<p>
-						<a href="privacy-policy.html#cookie-description" data-i18n="footer.privacy-policy">
+						<a href="policies/privacy-policy.html#cookie-description" data-i18n="footer.privacy-policy">
 							Privacy Policy
 						</a>
 					</p>

--- a/pricing.html
+++ b/pricing.html
@@ -339,11 +339,11 @@
             <h2>Turing Certs</h2>
             <ul class="list-inline-dash margin-top-30">
               <li>
-                <a href="information-security-policy.html" data-i18n="footer.security-policy">Information Security
+                <a href="policies/information-security-policy.html" data-i18n="footer.security-policy">Information Security
                   Policy</a>
               </li>
               <li>
-                <a href="privacy-policy.html" data-i18n="footer.privacy-policy">Privacy Policy</a>
+                <a href="policies/privacy-policy.html" data-i18n="footer.privacy-policy">Privacy Policy</a>
               </li>
             </ul>
             <p class="margin-top-10">


### PR DESCRIPTION
補上 cookie 區塊上的隱私權政策連結 & 修正 pricing 頁面(未公開)的隱私權政策與資安政策連結